### PR TITLE
Revert "Revert "init: Temporarily increase coldboot timeout to 5s""

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -642,7 +642,7 @@ static int wait_for_coldboot_done_action(int nargs, char **args) {
     // Any longer than 1s is an unreasonable length of time to delay booting.
     // If you're hitting this timeout, check that you didn't make your
     // sepolicy regular expressions too expensive (http://b/19899875).
-    if (wait_for_file(COLDBOOT_DONE, 1)) {
+    if (wait_for_file(COLDBOOT_DONE, 5)) {
         ERROR("Timed out waiting for %s\n", COLDBOOT_DONE);
     }
 


### PR DESCRIPTION
1 second might not be enough for some devices to complete
the coldboot phase, so bring the timeout back to 5 seconds.

This reverts commit c9e804ffd8d4108806eb8162fe7cf35f179b0596.

Change-Id: If10cd4bb1ea66d1c98cdd16f5bfbdae7a04b52e8
