### PR TITLE
rootdir: Put bootanimation service in system-background group

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -693,6 +693,7 @@ service bootanim /system/bin/bootanimation
     group graphics audio
     disabled
     oneshot
+    writepid /dev/cpuset/system-background/tasks
 
 service gatekeeperd /system/bin/gatekeeperd /data/misc/gatekeeper
     class late_start


### PR DESCRIPTION
- This keeps it from hogging the big cores and heating up the
  device.

Change-Id: I0ba6abef537ad65978dd77ec706f6e3777cac804
